### PR TITLE
Dockerized and Gradle changes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:10-jre-slim as productionstage
+COPY src src
+COPY build.gradle .
+COPY settings.gradle .
+COPY application.properties .
+COPY gradlew .
+COPY gradle gradle
+RUN ["./gradlew", "build"]
+ENTRYPOINT ["./gradlew", "bootRun"]

--- a/build.gradle
+++ b/build.gradle
@@ -31,5 +31,6 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter-data-jpa'
     // MySQL connector
     compile 'mysql:mysql-connector-java'
+    compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
     testCompile('org.springframework.boot:spring-boot-starter-test')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Wed Nov 28 11:26:44 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip


### PR DESCRIPTION
# Gradle Build
De applicatie kon alleen maar starten vanuit de IDE (op mijn machine, in ieder geval). Door een dependency toe te voegen in de gradle.build kan de .jar file nu los van de IDE draaien. Dit is nodig om het werkend te krijgen in Docker.

# Gradle Wrapper
Onze Gradle Wrapper was alweer een aantal maanden oud, dus die heb ik geüpdatet naar 5.0. Door de wrapper te gebruiken voor het builden (ipv je eigen geïnstalleerde Gradle), zijn we er zeker van dat het bij ons allemaal op dezelfde manier gebeurt. 

Dit zal dan ook door Docker gebruikt worden.

# Docker 101
Als je de applicatie wil starten via Docker dan kan je daarvoor de volgende stappen uitvoeren vanuit de project root:
- Bouw de image:
```bash
docker build -t htg/spring-wms .
```
- Start de container:
```bash
docker run --name spring-wms -p 8080:8080 -t htg/spring-wms
```
Je kan de container op een andere poort laten luisteren door de waarde links van de ':' te veranderen. Dat is wel handig als er getest moet worden met de frontend, zolang Spring op de standaard poort blijft ingesteld.

- Stop en verwijder de container (niet de image):
```bash
docker rm -f spring-wms
```
