### PR TITLE
added Role entity and addRole + removeRole mutations

### DIFF
--- a/src/main/java/entity/Role.java
+++ b/src/main/java/entity/Role.java
@@ -1,0 +1,47 @@
+package entity;
+
+import javax.persistence.*;
+import java.util.Set;
+
+@Entity // This tells Hibernate to make a table out of this class
+public class Role {
+    // fields
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+
+    private String name;
+
+    @ManyToMany(fetch = FetchType.EAGER, mappedBy = "roles")
+    private Set<User> users;
+
+    // getters
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Set<User> getUsers() {
+        return users;
+    }
+
+    // setters
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setUsers(Set<User> users) {
+        this.users = users;
+    }
+
+    public void addUser(User user) {
+        this.users.add(user);
+    }
+}

--- a/src/main/java/entity/User.java
+++ b/src/main/java/entity/User.java
@@ -3,10 +3,9 @@ package entity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.mindrot.jbcrypt.BCrypt;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.util.Optional;
+import java.util.Set;
 
 @JsonIgnoreProperties({"password"}) // never return the password!
 @Entity // This tells Hibernate to make a table out of this class
@@ -25,6 +24,10 @@ public class User {
     private String password;
 
     private String token;
+
+    @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.MERGE)
+    @JoinTable
+    private Set<Role> roles;
 
     // getters
     public Integer getId() {
@@ -49,6 +52,10 @@ public class User {
 
     public String getToken() {
         return token;
+    }
+
+    public Set<Role> getRoles() {
+        return roles;
     }
 
     // setters
@@ -77,5 +84,21 @@ public class User {
 
     public void setToken(String token) {
         this.token = token;
+    }
+
+    public void setRoles(Set<Role> roles) {
+        this.roles = roles;
+    }
+
+    public void addRole(Role role) {
+        this.roles.add(role);
+    }
+
+    public void removeRole(Role role) {
+        Optional<Role> result = this.roles.stream()
+            .parallel()
+            .filter(r -> r.getId().equals(role.getId()))
+            .findAny();
+        result.ifPresent(r -> this.roles.remove(r));
     }
 }

--- a/src/main/java/repository/RoleRepository.java
+++ b/src/main/java/repository/RoleRepository.java
@@ -1,0 +1,8 @@
+package repository;
+
+import entity.Role;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RoleRepository extends CrudRepository<Role, Integer> {
+
+}

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1,8 +1,15 @@
+type Role {
+    id: Int!
+    name: String!
+    users: [User]!
+}
+
 type User {
     id: Int!
     firstName: String!
     lastName: String!
     email: String!
+    roles: [Role]!
 }
 
 type LoginPayload {
@@ -58,6 +65,8 @@ type Mutation {
     itemRemoveCategory(itemId: Int!, categoryId: Int!): Item
 
     createUser(firstName: String!, lastName: String!, email: String!, password: String!): User
+    addRole(userId: Int!, roleId: Int!): User
+    removeRole(userId: Int!, roleId: Int!): User
 
     createLocation(code: String!, depth: Int!, width: Int!, height: Int!): Location
     deleteLocation(locationId: Int!): Boolean


### PR DESCRIPTION
Ik kon rollen van een gebruiker niet verwijderen door `this.roles.remove(role)` te doen.. Mogelijk is dit omdat deze call de `Role#equals` methode wilt gebruiken. Ik heb de equals methode dan ook geprobeerd te implementeren in de Role entity, maar dat wou maar niet lukken.

Dus vandaar dat ik er nu maar gewoon een stream van heb gemaakt.