### PR TITLE
createItem aangepast. updateItem toegevoegd. supplier zit nu ook in de mutaties.

### DIFF
--- a/src/main/java/entity/Item.java
+++ b/src/main/java/entity/Item.java
@@ -19,18 +19,18 @@ public class Item {
 
     @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.MERGE)
     @JoinTable
-    private Set<Category> categories;
+    private Set<Category> categories = new HashSet<>();
 
     @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.DETACH)
     private Supplier supplier;
 
-    public Item(String name, String code, Integer recommendedStock, Location location) {
+    public Item(String name, String code, Integer recommendedStock, Location location, Category category, Supplier supplier) {
         this.name = name;
-        this.code = code;
-        this.recommendedStock = recommendedStock;
-        this.locations = new HashSet<>();
-        locations.add(location);
-        this.categories = new HashSet<>();
+        if (code != null) this.code = code;
+        if (recommendedStock != null) this.recommendedStock = recommendedStock;
+        if (location != null) locations.add(location);
+        if (category != null) categories.add(category);
+        if (supplier != null) this.supplier = supplier;
     }
 
     public Item() {

--- a/src/main/java/graphql/Mutation.java
+++ b/src/main/java/graphql/Mutation.java
@@ -77,17 +77,45 @@ public class Mutation implements GraphQLMutationResolver {
         return new LoginPayload(token, user);
     }
 
-    public Item createItem(String name, String code, int recommendedStock, int locationId, DataFetchingEnvironment
+    public Item createItem(String name, String code, Integer recommendedStock, Integer locationId, Integer categoryId, Integer supplierId, DataFetchingEnvironment
         env) {
         AuthContext.requireAuth(env);
+
+        Location location = locationId == null ? null : locationRepository
+                .findById(locationId)
+                .orElseThrow(() -> new GraphQLException(idNotFoundMessage(locationId, Location.class.getSimpleName())));
+
+        Category category = categoryId == null ? null : categoryRepository
+                .findById(categoryId)
+                .orElseThrow(() -> new GraphQLException(idNotFoundMessage(categoryId, Category.class.getSimpleName())));
+
+        Supplier supplier = supplierId == null ? null : supplierRepository
+                .findById(supplierId)
+                .orElseThrow(() -> new GraphQLException(idNotFoundMessage(supplierId, Supplier.class.getSimpleName())));
 
         return itemRepository.save(new Item(
             name,
             code,
             recommendedStock,
-            locationRepository
-                .findById(locationId)
-                .orElseThrow(() -> new GraphQLException(idNotFoundMessage(locationId, Location.class.getSimpleName())))));
+            location,
+            category,
+            supplier
+        ));
+    }
+
+    public Item updateItem(Integer itemId, String name, String code, Integer recommendedStock, Integer supplierId) {
+        Item item = itemRepository
+                .findById(itemId)
+                .orElseThrow(() -> new GraphQLException(idNotFoundMessage(itemId, Item.class.getSimpleName())));
+
+        if (name != null) item.setName(name);
+        if (code != null) item.setCode(code);
+        if (recommendedStock != null) item.setRecommendedStock(recommendedStock);
+        if (supplierId != null) item.setSupplier(supplierRepository
+                .findById(supplierId)
+                .orElseThrow(() -> new GraphQLException(idNotFoundMessage(supplierId, Supplier.class.getSimpleName()))));
+
+        return itemRepository.save(item);
     }
 
     public Location createLocation(String code, int depth, int width, int height, DataFetchingEnvironment env) {

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -23,10 +23,10 @@ type LoginPayload {
 type Item {
     id: Int!
     name: String!
-    code: String!
-    recommendedStock: Int!
-    locations: [Location]!
-    categories: [Category]!
+    code: String
+    recommendedStock: Int
+    locations: [Location]
+    categories: [Category]
     supplier: Supplier
 }
 
@@ -130,7 +130,8 @@ type Mutation {
     updateSupplier(name: String!, id: Int!): Supplier
     deleteSupplier(id: Int!): Supplier
 
-    createItem(name: String!, code: String!, recommendedStock: Int!, locationId: Int!): Item
+    createItem(name: String!, code: String, recommendedStock: Int, locationId: Int, categoryId: Int, supplierId: Int): Item
+    updateItem(itemId: Int!, name: String, code: String, recommendedStock: Int, supplierId: Int): Item
     deleteItem(itemId: Int!): Boolean
     itemAddLocation(itemId: Int!, locationId: Int!): Item
     itemRemoveLocation(itemId: Int!, locationId: Int!): Item


### PR DESCRIPTION
# CreateItem mutatie aangepast
@femkeh Dit is zo aangepast dat het de huidige frontend niet kapot maakt.
- `code` is nu optioneel. Het lijkt met niet dat we de gebruikers moeten dwingen om een code in te vullen voor elk nieuw product. Kunnen we overleggen met Ronald.
- `recommendedStock` is  optioneel.
- `location` is optioneel. Wel handig om dit ook nog even te overleggen met Ronald.
- `category` is optioneel.
- `supplier` is  toegevoegd als optionele argument.

# UpdateItem mutatie toegevoegd
Van item kan je nu de eigenschappen `name`, `code`, `recommendedStock` en `supplier` wijzigen.

Hierbij zijn `locations` en `categories` niet meegenomen vanwege de many-to-many relatie. Daarvoor gebruik je de bestaande mutaties: itemAddLocation, itemAddCategory, itemRemoveLocation, itemRemoveCategory.