### PR TITLE
Feature/balance per location

### DIFF
--- a/src/main/java/entity/Account.java
+++ b/src/main/java/entity/Account.java
@@ -2,6 +2,7 @@ package entity;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
 
 @Entity
 public class Account {
@@ -17,8 +18,18 @@ public class Account {
     @Column(nullable = false, unique = true)
     private String name;
 
+    @OneToOne
+    private Location location;
+
+    private LocalDate deletedDate;
+
     public Account(@NotNull String name) {
         this.name = name;
+    }
+
+    public Account(String name, Location location) {
+        this.name = name;
+        this.location = location;
     }
 
     public Account() {
@@ -38,5 +49,21 @@ public class Account {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public void setLocation(Location location) {
+        this.location = location;
+    }
+
+    public LocalDate getDeletedDate() {
+        return deletedDate;
+    }
+
+    public void setDeletedDate(LocalDate deletedDate) {
+        this.deletedDate = deletedDate;
     }
 }

--- a/src/main/java/entity/Location.java
+++ b/src/main/java/entity/Location.java
@@ -16,6 +16,9 @@ public class Location {
     @ManyToMany(fetch = FetchType.EAGER, mappedBy = "locations")
     private Set<Item> items = new HashSet<>();
 
+    @OneToOne(mappedBy = "location")
+    private Account account;
+
     @ManyToMany(fetch = FetchType.EAGER, mappedBy = "locations")
     private Set<Category> categories = new HashSet<>();
 
@@ -83,5 +86,13 @@ public class Location {
 
     public void setCategories(Set<Category> categories) {
         this.categories = categories;
+    }
+
+    public Account getAccount() {
+        return account;
+    }
+
+    public void setAccount(Account account) {
+        this.account = account;
     }
 }

--- a/src/main/java/entity/Transaction.java
+++ b/src/main/java/entity/Transaction.java
@@ -89,6 +89,7 @@ public class Transaction {
     }
 
     public void setDeletedDate(LocalDate deletedDate) {
+        if (this.locked) throw new GraphQLException(LOCKED_MESSAGE);
         this.deletedDate = deletedDate;
         this.updateDate = LocalDate.now();
     }
@@ -100,6 +101,7 @@ public class Transaction {
     public void setPlannedDate(LocalDate plannedDate) {
         if (this.locked) throw new GraphQLException(LOCKED_MESSAGE);
         this.plannedDate = plannedDate;
+        this.updateDate = LocalDate.now();
     }
 
     public LocalDate getReceivedDate() {
@@ -117,7 +119,9 @@ public class Transaction {
     }
 
     public void setDescription(String description) {
+        if (this.locked) throw new GraphQLException(LOCKED_MESSAGE);
         this.description = description;
+        this.updateDate = LocalDate.now();
     }
 
     public Boolean getLocked() {
@@ -125,7 +129,9 @@ public class Transaction {
     }
 
     public void setLocked(Boolean locked) {
+        if (this.locked) throw new GraphQLException(LOCKED_MESSAGE);
         this.locked = locked;
+        this.updateDate = LocalDate.now();
     }
 
     public Account getFromAccount() {
@@ -134,6 +140,7 @@ public class Transaction {
 
     public void setFromAccount(Account fromAccount) {
         if (this.locked) throw new GraphQLException(LOCKED_MESSAGE);
+        this.updateDate = LocalDate.now();
         this.fromAccount = fromAccount;
     }
 
@@ -143,6 +150,7 @@ public class Transaction {
 
     public void setToAccount(Account toAccount) {
         if (this.locked) throw new GraphQLException(LOCKED_MESSAGE);
+        this.updateDate = LocalDate.now();
         this.toAccount = toAccount;
     }
 
@@ -151,6 +159,7 @@ public class Transaction {
     }
 
     public void setTransactionLines(Set<TransactionLine> transactionLines) {
+        if (this.locked) throw new GraphQLException(LOCKED_MESSAGE);
         this.transactionLines = transactionLines;
     }
 }

--- a/src/main/java/graphql/Mutation.java
+++ b/src/main/java/graphql/Mutation.java
@@ -565,6 +565,9 @@ public class Mutation implements GraphQLMutationResolver {
         if (toAccountId != null)
             transaction.setToAccount(accountRepository.findById(toAccountId).orElseThrow(() -> new GraphQLException(idNotFoundMessage(toAccountId, Account.class.getSimpleName()))));
 
+        if (plannedDate != null)
+            transaction.setPlannedDate(plannedDate);
+
         if (description != null)
             transaction.setDescription(description);
 

--- a/src/main/java/graphql/Mutation.java
+++ b/src/main/java/graphql/Mutation.java
@@ -558,7 +558,7 @@ public class Mutation implements GraphQLMutationResolver {
             .orElseThrow(() -> new GraphQLException(idNotFoundMessage(transactionId, Transaction.class.getSimpleName())));
 
 
-        // TODO balance checks
+        // TODO balance checks?
         if (fromAccountId != null)
             transaction.setFromAccount(accountRepository.findById(fromAccountId).orElseThrow(() -> new GraphQLException(idNotFoundMessage(fromAccountId, Account.class.getSimpleName()))));
 
@@ -684,6 +684,12 @@ public class Mutation implements GraphQLMutationResolver {
 
         if (transaction.getDeletedDate() != null)
             throw new GraphQLException("This transaction has been deleted, and therefore, can not be executed.");
+
+        if (transaction.getReceivedDate() != null)
+            throw new GraphQLException("This transaction has already been received, and therefore, can not be executed.");
+
+        if (transaction.getLocked())
+            throw new GraphQLException("This transaction is locked, and therefore, can not be executed.");
 
         safeTransactionCheck(transaction);
         processBalanceChanges(transaction);

--- a/src/main/java/graphql/Mutation.java
+++ b/src/main/java/graphql/Mutation.java
@@ -527,6 +527,9 @@ public class Mutation implements GraphQLMutationResolver {
                 throw new GraphQLException(idNotFoundMessage(itemId, Item.class.getSimpleName()));
         }
 
+        if (fromAccount.getDeletedDate() != null || toAccount.getDeletedDate() != null)
+            throw new GraphQLException("One or both accounts in this transaction has been set to inactive.");
+
         Transaction transaction = transactionRepository.save(new Transaction(fromAccount, toAccount, plannedDate, description));
         if (itemId != null && amount != null) addLineToTransaction(transaction.getId(), itemId, amount, env);
 
@@ -687,6 +690,9 @@ public class Mutation implements GraphQLMutationResolver {
 
         if (transaction.getLocked())
             throw new GraphQLException("This transaction is locked, and therefore, can not be executed.");
+
+        if (transaction.getFromAccount().getDeletedDate() != null || transaction.getToAccount().getDeletedDate() != null)
+            throw new GraphQLException("One or both accounts in this transaction has been set to inactive.");
 
         safeTransactionCheck(transaction);
         processBalanceChanges(transaction);

--- a/src/main/java/graphql/Mutation.java
+++ b/src/main/java/graphql/Mutation.java
@@ -427,13 +427,7 @@ public class Mutation implements GraphQLMutationResolver {
             .findById(itemId)
             .orElseThrow(() -> new GraphQLException(idNotFoundMessage(itemId, Item.class.getSimpleName())));
 
-        Account account;
-        if (accountId == null)
-            account = accountRepository
-                .findByName(Account.WAREHOUSE)
-                .orElseGet(() -> accountRepository.save(new Account(Account.WAREHOUSE)));
-        else
-            account = accountRepository
+        Account account = accountRepository
                 .findById(accountId)
                 .orElseThrow(() -> new GraphQLException(idNotFoundMessage(accountId, Account.class.getSimpleName())));
 
@@ -512,24 +506,16 @@ public class Mutation implements GraphQLMutationResolver {
         return createTransaction(fromAccount, toAccount, plannedDate, description, itemId, amount, env);
     }
 
-    public Transaction createLocationTransaction(Integer itemId, Integer amount, LocalDate plannedDate, String description, Integer locationId, DataFetchingEnvironment env) {
+    public Transaction createLocationTransaction(Integer itemId, Integer amount, LocalDate plannedDate, String description, Integer fromLocationId, Integer toLocationId, DataFetchingEnvironment env) {
         AuthContext.requireAuth(env);
 
-        Account fromAccount = locationId == null
-                ? accountRepository
-                    .findByName(Account.WAREHOUSE)
-                    .orElseGet(() -> accountRepository.save(new Account(Account.WAREHOUSE)))
-                : accountRepository
-                    .findByLocationId(locationId)
-                    .orElseThrow(() -> new GraphQLException(idNotFoundMessage(locationId, Location.class.getSimpleName())));
+        Account fromAccount = accountRepository
+                .findByLocationId(fromLocationId)
+                .orElseThrow(() -> new GraphQLException(idNotFoundMessage(fromLocationId, Location.class.getSimpleName())));
 
-        Account toAccount = locationId == null
-                ? accountRepository
-                    .findByName(Account.WAREHOUSE)
-                    .orElseGet(() -> accountRepository.save(new Account(Account.WAREHOUSE)))
-                : accountRepository
-                    .findByLocationId(locationId)
-                    .orElseThrow(() -> new GraphQLException(idNotFoundMessage(locationId, Location.class.getSimpleName())));
+        Account toAccount = accountRepository
+                .findByLocationId(toLocationId)
+                .orElseThrow(() -> new GraphQLException(idNotFoundMessage(toLocationId, Location.class.getSimpleName())));
 
         return createTransaction(fromAccount, toAccount, plannedDate, description, itemId, amount, env);
     }

--- a/src/main/java/graphql/Query.java
+++ b/src/main/java/graphql/Query.java
@@ -171,10 +171,18 @@ public class Query implements GraphQLQueryResolver {
         return accountRepository.findById(id).orElse(null);
     }
 
-    public List<Account> getAccounts(DataFetchingEnvironment env) {
+    public List<Account> getAccounts(Boolean showDeleted, DataFetchingEnvironment env) {
         AuthContext.requireAuth(env);
 
-        return ((List<Account>) accountRepository.findAll());
+        ArrayList<Account> accounts = new ArrayList<>(((List<Account>) accountRepository.findAll()));
+
+        if (showDeleted == null || !showDeleted) {
+            ArrayList<Account> toRemove = new ArrayList<>();
+            for (Account account : accounts) if (account.getDeletedDate() != null) toRemove.add(account);
+            accounts.removeAll(toRemove);
+        }
+
+        return accounts;
     }
 
     public Balance getBalance(Integer id, DataFetchingEnvironment env) {

--- a/src/main/java/graphql/Query.java
+++ b/src/main/java/graphql/Query.java
@@ -136,22 +136,25 @@ public class Query implements GraphQLQueryResolver {
         return transactionRepository.findById(id).orElse(null);
     }
 
-    public List<Transaction> getTransactions(Boolean showDeleted, Boolean showOrders, Boolean showReservations, Boolean showReturns, DataFetchingEnvironment env) {
+    public List<Transaction> getTransactions(Boolean showDeleted, Boolean showOrders, Boolean showReservations, Boolean showReturns, Boolean showLocations, DataFetchingEnvironment env) {
         AuthContext.requireAuth(env);
 
         ArrayList<Transaction> transactions = new ArrayList<>();
 
         if (showOrders != null && showOrders) {
-            transactions.addAll((List<Transaction>) transactionRepository.findAllByFromAccountName(Account.SUPPLIER));
+            transactions.addAll((List<Transaction>) transactionRepository.findAllByFromAccountNameAndToAccountName(Account.SUPPLIER, Account.WAREHOUSE));
         }
 
         if (showReservations != null && showReservations) {
-            transactions.addAll((List<Transaction>) transactionRepository.findAllByFromAccountName(Account.WAREHOUSE));
+            transactions.addAll((List<Transaction>) transactionRepository.findAllByFromAccountNameAndToAccountName(Account.WAREHOUSE, Account.IN_USE));
         }
 
         if (showReturns != null && showReturns) {
-            transactions.addAll((List<Transaction>) transactionRepository.findAllByFromAccountName(Account.IN_USE));
+            transactions.addAll((List<Transaction>) transactionRepository.findAllByFromAccountNameAndToAccountName(Account.IN_USE, Account.WAREHOUSE));
         }
+
+        if (showLocations != null || showLocations)
+            transactions.addAll((List<Transaction>) transactionRepository.findAllByFromAccountNameAndToAccountName(Account.WAREHOUSE, Account.WAREHOUSE));
 
         if (showDeleted == null || !showDeleted) {
             ArrayList<Transaction> toRemove = new ArrayList<>();

--- a/src/main/java/repository/AccountRepository.java
+++ b/src/main/java/repository/AccountRepository.java
@@ -13,5 +13,9 @@ public interface AccountRepository extends CrudRepository<Account, Integer> {
         return findByName(account == null ? null : account.getName());
     }
 
+    Optional<Account> findByLocationId(int locationId);
 
+    default Optional<Account> findByLocationId(Account account) {
+        return findByLocationId(account == null ? null : account.getLocation().getId());
+    }
 }

--- a/src/main/java/repository/TransactionRepository.java
+++ b/src/main/java/repository/TransactionRepository.java
@@ -4,9 +4,9 @@ import entity.Transaction;
 import org.springframework.data.repository.CrudRepository;
 
 public interface TransactionRepository extends CrudRepository<Transaction, Integer> {
-    Iterable<Transaction> findAllByFromAccountName(String name);
+    Iterable<Transaction> findAllByFromAccountNameAndToAccountName(String fromName, String toName);
 
-    default Iterable<Transaction> findAllByFromAccountName(Transaction transaction) {
-        return findAllByFromAccountName(transaction == null ? null : transaction.getFromAccount().getName());
+    default Iterable<Transaction> findAllByFromAccountNameAndToAccountName(Transaction transaction) {
+        return findAllByFromAccountNameAndToAccountName(transaction == null ? null : transaction.getFromAccount().getName(), transaction == null ? null : transaction.getToAccount().getName());
     }
 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -113,7 +113,7 @@ type Query {
     category(id: Int!): Category
 
     # All the parameters are false by default.
-    transactions(showDeleted: Boolean, showOrders: Boolean, showReservations: Boolean, showReturns: Boolean): [Transaction]!
+    transactions(showDeleted: Boolean, showOrders: Boolean, showReservations: Boolean, showReturns: Boolean, showLocation: Boolean): [Transaction]!
 
     transaction(id: Int!): Transaction
     transactionLines: [TransactionLine]!
@@ -165,8 +165,8 @@ type Mutation {
     # Creates an account representing the in-use items. Not keeping track of items outside of the warehouse because it is out-of-scope.
     createInUseAccount: Account
 
-    # Every item in the warehouse needs a balance to see how much of it is in stock. Default account is warehouse.
-    createBalance(itemId: Int!, accountId: Int, amount: Int): Balance
+    # Every item in the warehouse needs a balance to see how much of it is in stock. Default amount is 0.
+    createBalance(itemId: Int!, accountId: Int!, amount: Int): Balance
 
     # Sets the balance to given amount. Creates a balance mutation along with a default reason, if not specified.
     setBalance(balanceId: Int!, amount: Int!): Balance
@@ -179,6 +179,9 @@ type Mutation {
 
     # Transaction that takes items into the warehouse. Adding a line is optional.
     createReturnTransaction(itemId: Int, amount: Int, plannedDate: LocalDate, description: String, locationId: Int): Transaction
+
+    # Transaction that moves items between locations inside of the warehouse. Adding a line is optional.
+    createLocationTransaction(itemId: Int, amount: Int, plannedDate: LocalDate, description: String, fromLocationId: Int!, toLocationId: Int!): Transaction
 
     # Adds line to transaction. Default planned date is today.
     addLineToTransaction(transactionId: Int!, itemId: Int!, amount: Int!): TransactionLine

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -118,7 +118,7 @@ type Query {
     transaction(id: Int!): Transaction
     transactionLines: [TransactionLine]!
     transactionLine(id: Int!): TransactionLine
-    accounts: [Account]!
+    accounts(showDeleted: Boolean): [Account]!
     account(id: Int!): Account
     balances: [Balance]!
     balance(id: Int!): Balance

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -46,6 +46,7 @@ type Location {
     height: Int!
     items: [Item]!
     categories: [Category]!
+    account: Account
 }
 
 type Supplier {
@@ -84,6 +85,8 @@ type TransactionLine {
 type Account {
     id: Int!
     name: String!
+    location: Location
+    deletedDate: LocalDate
 }
 
 type Balance {

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -172,13 +172,13 @@ type Mutation {
     setBalance(balanceId: Int!, amount: Int!, reason: String): Balance
 
     # Transaction that takes items out of the warehouse. Adding a line is optional.
-    createReservationTransaction(itemId: Int, amount: Int, plannedDate: LocalDate, description: String): Transaction
+    createReservationTransaction(itemId: Int, amount: Int, plannedDate: LocalDate, description: String, locationId: Int): Transaction
 
     # Transaction that represents an order from a supplier to the warehouse. Adding a line is optional.
-    createOrderTransaction(itemId: Int, amount: Int, plannedDate: LocalDate, description: String): Transaction
+    createOrderTransaction(itemId: Int, amount: Int, plannedDate: LocalDate, description: String, locationId: Int): Transaction
 
     # Transaction that takes items into the warehouse. Adding a line is optional.
-    createReturnTransaction(itemId: Int, amount: Int, plannedDate: LocalDate, description: String): Transaction
+    createReturnTransaction(itemId: Int, amount: Int, plannedDate: LocalDate, description: String, locationId: Int): Transaction
 
     # Adds line to transaction. Default planned date is today.
     addLineToTransaction(transactionId: Int!, itemId: Int!, amount: Int!): TransactionLine

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -169,7 +169,7 @@ type Mutation {
     createBalance(itemId: Int!, accountId: Int, amount: Int): Balance
 
     # Sets the balance to given amount. Creates a balance mutation along with a default reason, if not specified.
-    setBalance(balanceId: Int!, amount: Int!, reason: String): Balance
+    setBalance(balanceId: Int!, amount: Int!): Balance
 
     # Transaction that takes items out of the warehouse. Adding a line is optional.
     createReservationTransaction(itemId: Int, amount: Int, plannedDate: LocalDate, description: String, locationId: Int): Transaction


### PR DESCRIPTION
- Linked Account to Location.
- Added field `deletedDate` to Account.
- When deleting a Location, the account linked to it will have `deletedDate` set to the current day and the account name changed to `<currentname> location: <location code> (deleted)`.
- It is not possible to create or execute a transaction of which either one or both of the accounts are deleted.
- Added optional parameter Boolean `showDeleted` to query `accounts`.
- Fixed bug in mutation `updateTransaction` where `plannedDate` wont change.
- Fixed bug in mutation `updateTransaction` where `updateDate` wont update.
- Added missing execution restrictions.
- Mutations creating a transaction involving the warehouse now have an optional parameter `locationId` to specify the location in the warehouse. If it is not specified, the item(s) will end up in the warehouse without a location.
- Added parameter `locationId` to `createBalance`.
- Added mutation `createLocationTransaction` to move items between locations within the warehouse.